### PR TITLE
Fixed NPE, again

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/pipeline/FluidRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/pipeline/FluidRenderer.java
@@ -130,6 +130,10 @@ public class FluidRenderer {
 
         Sprite[] sprites = ForgeHooksClient.getFluidSprites(world, blockPos, fluidState);
 
+        if (sprites[2] == null) {
+            sprites[2] = sprites[0];
+        }
+        
         float fluidHeight = this.fluidHeight(world, fluid, blockPos, Direction.UP);
         float northWestHeight, southWestHeight, southEastHeight, northEastHeight;
         if (fluidHeight >= 1.0f) {


### PR DESCRIPTION
A dirty fix for one Null Pointer that kept happening even after it was "fixed" with https://github.com/CaffeineMC/sodium-fabric/commit/86966a781bc2b7b31c3b95cd521ba5a0f1bf11c0

As a proof, here's me looking at that damned iron farm that [crashed my game](https://discord.com/channels/997199744923336704/1147962967560826962/1155965624816783420)

![2023-09-26_13 53 59](https://github.com/Reforged-Hub/rubidium-upstream/assets/63512006/8ccf37db-459e-4e71-a05c-85941816a457)
